### PR TITLE
Add space in Content-Type header to satisfy Exchange 2010 Web Service interface

### DIFF
--- a/lib/handsoap/service.rb
+++ b/lib/handsoap/service.rb
@@ -241,7 +241,7 @@ module Handsoap
         end
         # ready to dispatch
         headers = {
-          "Content-Type" => "#{self.request_content_type};charset=UTF-8"
+          "Content-Type" => "#{self.request_content_type}; charset=UTF-8"
         }
         headers["SOAPAction"] = options[:soap_action] unless options[:soap_action].nil?
         on_before_dispatch
@@ -287,7 +287,7 @@ module Handsoap
         dispatcher.request_block.call doc.find(action)
         # ready to dispatch
         headers = {
-          "Content-Type" => "#{self.request_content_type};charset=UTF-8"
+          "Content-Type" => "#{self.request_content_type}; charset=UTF-8"
         }
         headers["SOAPAction"] = options[:soap_action] unless options[:soap_action].nil?
         on_before_dispatch


### PR DESCRIPTION
The Exchange 2010 Web Services interface expects a space after the semicolon in the Content-Type header, 'text/xml; charset=utf-8' instead of 'text/xml;charset=utf-8'. Without the space included, it returns the following error message:

```
"HTTP/1.1 415 Cannot process the message because the content type 'text/xml;charset=utf-8' was not the expected type 'text/xml; charset=utf-8'."
```

While I would consider it a bug in the Exchange 2010 server since it doesn't look like a space is required, the examples in [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) do include spaces.

Here's a [thread on stackoverflow](http://stackoverflow.com/questions/1913856/problem-consuming-exchange-web-service-2010-with-jax-ws-metro) that discusses the problem.

This patch simply adds a space to address this issue.
