### PR TITLE
net http driver raises ArgumentError (HTTP request path is empty)

### DIFF
--- a/lib/handsoap/http/drivers/net_http_driver.rb
+++ b/lib/handsoap/http/drivers/net_http_driver.rb
@@ -15,9 +15,7 @@ module Handsoap
             url = ::URI.parse(url)
           end
 
-          path = url.path
-          # Net::HTTP will blow otherwise
-          path = '/' if path.blank?
+          path = url.request_uri
 
           http_request = case request.http_method
                          when :get

--- a/lib/handsoap/http/drivers/net_http_driver.rb
+++ b/lib/handsoap/http/drivers/net_http_driver.rb
@@ -14,8 +14,12 @@ module Handsoap
           unless url.kind_of? ::URI::Generic
             url = ::URI.parse(url)
           end
+
           ::URI::Generic.send(:public, :path_query) # hackety hack
           path = url.path_query
+          # Net::HTTP will blow otherwise
+          path = '/' if path.blank?
+
           http_request = case request.http_method
                          when :get
                            Net::HTTP::Get.new(path)

--- a/lib/handsoap/http/drivers/net_http_driver.rb
+++ b/lib/handsoap/http/drivers/net_http_driver.rb
@@ -15,8 +15,7 @@ module Handsoap
             url = ::URI.parse(url)
           end
 
-          ::URI::Generic.send(:public, :path_query) # hackety hack
-          path = url.path_query
+          path = url.path
           # Net::HTTP will blow otherwise
           path = '/' if path.blank?
 


### PR DESCRIPTION
Basically this fixes the problem with net-http driver and root-level uris like https://example.com. Otherwise it raises error. Also got rid  of useless call to private method.
